### PR TITLE
feat: inline external references during validation construction

### DIFF
--- a/src/method-call-validator/method-call-validator.test.ts
+++ b/src/method-call-validator/method-call-validator.test.ts
@@ -11,7 +11,28 @@ const getExampleSchema = (): OpenRPC => ({
       params: [{ name: "foofoo", schema: { type: "string" } }],
       result: { name: "foofoo", schema: { type: "integer" } },
     },
+    {
+      name: "externalReference",
+      params: [{ name: "extRef", schema: { $ref: "#/components/schemas/ExtRef" } }],
+      result: { name: "extRefResult", schema: { $ref: "#/components/schemas/ExtRef" } },
+    },
   ],
+  components: {
+    schemas: {
+      ExtRef: {
+        title: "extRef",
+        type: "object",
+        required: [
+          "reference",
+        ],
+        properties: {
+          reference: {
+            type: "string",
+          }
+        }
+      }
+    }
+  },
   openrpc: "1.0.0-rc1",
 }) as OpenRPC;
 
@@ -21,55 +42,62 @@ describe("MethodCallValidator", () => {
     expect(new MethodCallValidator(example)).toBeInstanceOf(MethodCallValidator);
   });
 
-  it("can validate a method call", () => {
+  it("can validate a method call", async () => {
     const example = getExampleSchema();
     const methodCallValidator = new MethodCallValidator(example);
-    const result = methodCallValidator.validate("foo", ["foobar"]);
+    let result = await methodCallValidator.validate("foo", ["foobar"]);
+    expect(result).toEqual([]);
+    result = await methodCallValidator.validate("externalReference", [{ "reference": "extra" }]);
     expect(result).toEqual([]);
   });
 
-  it("can handle having params undefined", () => {
+  it("can handle having params undefined", async () => {
     const example = getExampleSchema();
     delete example.methods[0].params;
     const methodCallValidator = new MethodCallValidator(example);
-    const result = methodCallValidator.validate("foo", ["foobar"]);
+    const result = await methodCallValidator.validate("foo", ["foobar"]);
     expect(result).toEqual([]);
   });
 
-  it("can handle having schema undefined", () => {
+  it("can handle having schema undefined", async () => {
     const example = getExampleSchema() as any;
     delete example.methods[0].params[0].schema;
     const methodCallValidator = new MethodCallValidator(example);
-    const result = methodCallValidator.validate("foo", ["foobar"]);
+    const result = await methodCallValidator.validate("foo", ["foobar"]);
     expect(result).toEqual([]);
   });
 
-  it("returns array of errors if invalid", () => {
+  it("returns array of errors if invalid", async () => {
     const example = getExampleSchema() as any;
     const methodCallValidator = new MethodCallValidator(example);
-    const result = methodCallValidator.validate("foo", [123]) as MethodCallParameterValidationError[];
+    let result = await methodCallValidator.validate("foo", [123]) as MethodCallParameterValidationError[];
     expect(result.length).toBe(1);
     expect(result[0]).toBeInstanceOf(MethodCallParameterValidationError);
+
+    result = await methodCallValidator.validate("externalReference", [123]) as MethodCallParameterValidationError[];
+    expect(result.length).toBe(1);
+    expect(result[0]).toBeInstanceOf(MethodCallParameterValidationError);
+
   });
 
-  it("can not error if param is optional", () => {
+  it("can not error if param is optional", async () => {
     const example = getExampleSchema() as any;
     const methodCallValidator = new MethodCallValidator(example);
-    const result = methodCallValidator.validate("foo", []);
+    const result = await methodCallValidator.validate("foo", []);
     expect(result).toEqual([]);
   });
 
-  it("rpc.discover is allowed", () => {
+  it("rpc.discover is allowed", async () => {
     const example = getExampleSchema() as any;
     const methodCallValidator = new MethodCallValidator(example);
-    const result = methodCallValidator.validate("rpc.discover", []);
+    const result = await methodCallValidator.validate("rpc.discover", []);
     expect(result).toEqual([]);
   });
 
-  it("returns method not found error when the method name is invalid", () => {
+  it("returns method not found error when the method name is invalid", async () => {
     const example = getExampleSchema() as any;
     const methodCallValidator = new MethodCallValidator(example);
-    const result = methodCallValidator.validate("boo", ["123"]);
+    const result = await methodCallValidator.validate("boo", ["123"]);
     expect(result).toBeInstanceOf(MethodCallMethodNotFoundError);
   });
 });

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,7 @@
   ],
   "rules": {
     "ordered-imports": false,
-    "indent": [true, "spaces", 2]
+    "indent": [true, "spaces", 2],
+    "object-literal-sort-keys": false
   }
 }


### PR DESCRIPTION
This change is to fix a problem that occurs when downstream projects
attempt to validate openRPC documents. They need a way to resolve
in document references.

This change should have negligible performance impact, because the
resolution of the doucment is only performed on validation construction.
The cost of resolving the references, is required for the validation
process, so it should not add avoidable overhead.

Lastly this change should allow downstream components to resolve
references in a uniform way, without duplicating the process

fixes #125