### PR TITLE
feat: expose an option to support custom resolver resolution.

### DIFF
--- a/src/parse-open-rpc-document.ts
+++ b/src/parse-open-rpc-document.ts
@@ -114,7 +114,7 @@ const makeParseOpenRPCDocument = (fetchUrlSchema: TGetOpenRPCDocument, readSchem
 
     let postDeref: OpenrpcDocument = parsedSchema;
     if (parseOptions.dereference) {
-      if(parseOptions.resolver !== undefined){
+      if (parseOptions.resolver !== undefined) {
         postDeref = await dereferenceDocument(parsedSchema, parseOptions.resolver);
       } else {
         postDeref = await dereferenceDocument(parsedSchema, defaultResolver);

--- a/src/parse-open-rpc-document.ts
+++ b/src/parse-open-rpc-document.ts
@@ -4,6 +4,8 @@ import defaultResolver from "@json-schema-tools/reference-resolver"
 import isUrl = require("is-url");
 import { OpenrpcDocument } from "@open-rpc/meta-schema";
 import { TGetOpenRPCDocument } from "./get-open-rpc-document";
+import ReferenceResolver, { ProtocolHandlerMap } from "@json-schema-tools/reference-resolver/build/reference-resolver";
+export { JSONSchema } from "@json-schema-tools/meta-schema";
 
 /**
  * @ignore
@@ -34,6 +36,13 @@ export interface ParseOpenRPCDocumentOptions {
    *
    */
   dereference?: boolean;
+  /*
+   * Enable custom reference resolver. This will allow people to resolve 3rd party custom reference values like for ipfs.
+   *
+   * @default defaultReferenceResolver  
+   *
+   */
+  resolver?: ReferenceResolver;
 }
 
 const defaultParseOpenRPCDocumentOptions = {
@@ -105,7 +114,11 @@ const makeParseOpenRPCDocument = (fetchUrlSchema: TGetOpenRPCDocument, readSchem
 
     let postDeref: OpenrpcDocument = parsedSchema;
     if (parseOptions.dereference) {
-      postDeref = await dereferenceDocument(parsedSchema, defaultResolver);
+      if(parseOptions.resolver !== undefined){
+        postDeref = await dereferenceDocument(parsedSchema, parseOptions.resolver);
+      } else {
+        postDeref = await dereferenceDocument(parsedSchema, defaultResolver);
+      }
     }
 
     if (parseOptions.validate) {
@@ -118,5 +131,9 @@ const makeParseOpenRPCDocument = (fetchUrlSchema: TGetOpenRPCDocument, readSchem
     return postDeref;
   };
 };
+
+export function makeCustomResolver(protocolMapHandler: ProtocolHandlerMap): ReferenceResolver{
+  return new ReferenceResolver(protocolMapHandler);
+}
 
 export default makeParseOpenRPCDocument;


### PR DESCRIPTION
This feature exposes two separate entry points for creating a resolver,
one using the makeCustomResolver() option and another for advanced
users that want more or need more control over the resolution process,
which allows users to extend the resolver class if needed.

fixes #587