### PR TITLE
fix: handle notification examples

### DIFF
--- a/src/dereference-document.ts
+++ b/src/dereference-document.ts
@@ -138,7 +138,9 @@ const handleMethod = async (methodOrRef: MethodOrReference, doc: OpenrpcDocument
     method.examples = await derefItems(method.examples as ReferenceObject[], doc, resolver);
     for (const exPairing of method.examples as ExamplePairingObject[]) {
       exPairing.params = await derefItems(exPairing.params as ReferenceObject[], doc, resolver);
-      exPairing.result = await derefItem(exPairing.result as ReferenceObject, doc, resolver);
+      if (exPairing.result !== undefined) {
+        exPairing.result = await derefItem(exPairing.result as ReferenceObject, doc, resolver);
+      }
     }
   }
 

--- a/src/parse-open-rpc-document.test.ts
+++ b/src/parse-open-rpc-document.test.ts
@@ -35,6 +35,17 @@ const notificationDocument: OpenRPC = {
           schema: { "type": "boolean" },
         },
       ],
+      examples: [
+        {
+          name: "example",
+          params: [
+            {
+              name: "bar",
+              value: true,
+            },
+          ],
+        },
+      ]
     },
   ],
 };


### PR DESCRIPTION
Currently `parseOpenRPCDocument` fails on notification examples (without result). this PR is a fix for it.