### PR TITLE
fix 974: add web export for dereferenceDocument

### DIFF
--- a/src/index-web.ts
+++ b/src/index-web.ts
@@ -1,4 +1,5 @@
 import makeParseOpenRPCDocument from "./parse-open-rpc-document";
+import dereferenceDocument, { OpenRPCDocumentDereferencingError } from "./dereference-document";
 import validateOpenRPCDocument, {
   OpenRPCDocumentValidationError,
 } from "./validate-open-rpc-document";
@@ -23,6 +24,7 @@ const noop: TGetOpenRPCDocument = (schema: string) => {
 const parseOpenRPCDocument = makeParseOpenRPCDocument(fetchUrlSchema, noop);
 
 export {
+  dereferenceDocument,
   parseOpenRPCDocument,
   generateMethodParamId,
   generateMethodResultId,
@@ -33,5 +35,6 @@ export {
   MethodCallValidator,
   ParameterValidationError,
   OpenRPCDocumentValidationError,
+  OpenRPCDocumentDereferencingError,
   ContentDescriptorNotFoundInMethodError,
 };


### PR DESCRIPTION
Fixes #974 by adding `dereferenceDocument` and `OpenRPCDocumentDereferencingError` to the web exports to match `index.ts`.